### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 
 - Kosten der Reise: Nachkommastellen anzeigen
 
-- Datumsformat: Eurooäisch.
+- Datumsformat: Europäisch.
 - Datum: Wochentag ausgeben
 - **Zurück**-Link einfügen


### PR DESCRIPTION
I replaced `Eurooäisch` with `Europäisch`.